### PR TITLE
Added autoIndex option to Item annotation

### DIFF
--- a/Doctrine/DoctrineListener.php
+++ b/Doctrine/DoctrineListener.php
@@ -4,6 +4,7 @@ namespace Becklyn\SearchBundle\Doctrine;
 
 use Becklyn\SearchBundle\Entity\SearchableEntityInterface;
 use Becklyn\SearchBundle\Metadata\Metadata;
+use Becklyn\SearchBundle\Metadata\SearchItem;
 use Becklyn\SearchBundle\Search\SearchIndexer;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
@@ -72,9 +73,10 @@ class DoctrineListener implements EventSubscriber
     {
         $entity = $args->getEntity();
 
+        /** @var $item SearchItem */
         foreach ($this->metadata->getAllItems() as $item)
         {
-            if (is_a($entity, $item->getFqcn()))
+            if (is_a($entity, $item->getFqcn()) && $item->isAutoIndexed())
             {
                 /** @var SearchableEntityInterface $entity */
                 $this->indexer->index($entity);

--- a/Mapping/Item.php
+++ b/Mapping/Item.php
@@ -21,4 +21,13 @@ class Item
      * @var string
      */
     public $loader = null;
+
+
+    /**
+     * Determines whether the searchable item should be indexed automatically
+     * whenever it's persisted or updated in Doctrine
+     *
+     * @var bool
+     */
+    public $autoIndex = true;
 }

--- a/Metadata/Extractor/ClassMetadataExtractor.php
+++ b/Metadata/Extractor/ClassMetadataExtractor.php
@@ -81,7 +81,8 @@ class ClassMetadataExtractor
             $class->getName(),
             $annotation->index ?: $this->generateElasticsearchTypeName($class),
             $class->implementsInterface(LocalizedSearchableEntityInterface::class),
-            $annotation->loader
+            $annotation->loader,
+            $annotation->autoIndex
         );
 
         // Collect all indexed properties

--- a/Metadata/SearchItem.php
+++ b/Metadata/SearchItem.php
@@ -48,19 +48,27 @@ class SearchItem
     private $loader;
 
 
+    /**
+     * @var bool
+     */
+    private $autoIndex = true;
+
+
 
     /**
      * @param string      $fqcn
      * @param string      $elasticsearchType
      * @param bool        $localized
      * @param string|null $loader
+     * @param bool        $autoIndex
      */
-    public function __construct (string $fqcn, string $elasticsearchType, bool $localized, string $loader = null)
+    public function __construct (string $fqcn, string $elasticsearchType, bool $localized, string $loader = null, bool $autoIndex = true)
     {
         $this->fqcn = $fqcn;
         $this->elasticsearchType = $elasticsearchType;
         $this->localized = $localized;
         $this->loader = $loader;
+        $this->autoIndex = $autoIndex;
     }
 
 
@@ -153,5 +161,14 @@ class SearchItem
         }
 
         $this->filters[$filter->getElasticsearchFieldName()] = $filter;
+    }
+
+
+    /**
+     * @return bool
+     */
+    public function isAutoIndexed () : bool
+    {
+        return $this->autoIndex;
     }
 }


### PR DESCRIPTION
This new option can then be used to determine whether a given entity should be automatically indexed via Doctrine’s lifecycle events `postPersist` and `postUpdate`.

If this option is set to `false` the application’s code is responsible to index the entity at some point.

This option does not affect manual indexing via the `becklyn:search:index` command