### PR TITLE
Use ClassUtils to display real class

### DIFF
--- a/Search/Result/SearchResultBuilder.php
+++ b/Search/Result/SearchResultBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Becklyn\SearchBundle\Search\Result;
 
+use Doctrine\Common\Util\ClassUtils;
+
 
 class SearchResultBuilder
 {
@@ -16,7 +18,7 @@ class SearchResultBuilder
     {
         $entity = $hit->getEntity();
         $id = $entity->getId();
-        $entityClass = get_class($entity);
+        $entityClass = ClassUtils::getRealClass(get_class($entity));
 
         if (isset($this->classMapping[$entityClass][$id]))
         {


### PR DESCRIPTION
Some entities use a proxyclass, when adding a SearchResult. e.g. lazy loaded entities.
But when building up our classMapping, we need the correct real class, otherways the result won't show up, when filtering for a certain FQCN.
The Doctrine ClassUtils will display the real class name and therefore provide a correct bundled search result.