### PR TITLE
Fix search bundle bundle namespace prefix in index command

### DIFF
--- a/Command/IndexCommand.php
+++ b/Command/IndexCommand.php
@@ -161,7 +161,7 @@ class IndexCommand extends Command
 
         foreach ($this->kernel->getBundles() as $bundle)
         {
-            $bundleNamespacePrefix = "{$bundle->getName()}\\";
+            $bundleNamespacePrefix = "{$bundle->getNamespace()}\\";
 
             $searchItems = $this->metadataGenerator->rebuildMetadata([
                 $bundleNamespacePrefix => $bundle->getPath(),

--- a/LanguageIntegration/ClassFinder.php
+++ b/LanguageIntegration/ClassFinder.php
@@ -57,6 +57,7 @@ class ClassFinder
             ->files()
             ->ignoreUnreadableDirs()
             ->name('*.php')
+            ->exclude(["Tests", "tests", "Test", "test", "Skeleton", "skeleton"])
             ->contains("class ");
 
         $classMap = [];


### PR DESCRIPTION
Currently the SearchBundle is generating the namespace of the bundles via `$bundle->getName()` instead of the namespace  via `$bundle->getNamespace()`, which is why the SearchBundle only supports projects where the namespace of the classes is equal to the bundle name.

This PR should fix this issue. Additionally it excludes failing directories, which weren't meant to be indexed in the first place but which are only now found because of the change to the generation of the namespaces.